### PR TITLE
fix: Serialize database initialization

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -9,106 +9,108 @@ const db = new sqlite3.Database(DBSOURCE, (err) => {
     } else {
         console.log('Connected to the SQLite database.');
 
-        // Users table
-        db.run(`CREATE TABLE IF NOT EXISTS users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            username TEXT UNIQUE,
-            password TEXT,
-            master_password_salt TEXT,
-            encrypted_vault_key TEXT,
-            two_fa_secret TEXT,
-            two_fa_enabled INTEGER DEFAULT 0,
-            CONSTRAINT username_unique UNIQUE (username)
-        )`,
-        (err) => {
-            if (err) {
-                // Table already exists
-            } else {
-                // Table just created
-                console.log('Users table created.');
-            }
+        db.serialize(() => {
+            // Users table
+            db.run(`CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE,
+                password TEXT,
+                master_password_salt TEXT,
+                encrypted_vault_key TEXT,
+                two_fa_secret TEXT,
+                two_fa_enabled INTEGER DEFAULT 0,
+                CONSTRAINT username_unique UNIQUE (username)
+            )`,
+            (err) => {
+                if (err) {
+                    // Table already exists
+                } else {
+                    // Table just created
+                    console.log('Users table created.');
+                }
+            });
+
+            // Passwords table
+            db.run(`CREATE TABLE IF NOT EXISTS passwords (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                site TEXT NOT NULL,
+                username TEXT NOT NULL,
+                password TEXT NOT NULL,
+                category TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )`,
+            (err) => {
+                if (err) {
+                    // Table already exists
+                } else {
+                    console.log('Passwords table created.');
+                }
+            });
+
+            // Password History table
+            db.run(`CREATE TABLE IF NOT EXISTS password_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                password_id INTEGER NOT NULL,
+                site TEXT NOT NULL,
+                username TEXT NOT NULL,
+                password TEXT NOT NULL,
+                category TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (password_id) REFERENCES passwords(id) ON DELETE CASCADE
+            )`,
+            (err) => {
+                if (err) { /* Table already exists */ } else { console.log('Password history table created.'); }
+            });
+
+            // Secure Notes table
+            db.run(`CREATE TABLE IF NOT EXISTS secure_notes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )`,
+            (err) => {
+                if (err) { /* Table already exists */ } else { console.log('Secure notes table created.'); }
+            });
+
+            db.run(`
+                CREATE TRIGGER IF NOT EXISTS update_notes_updated_at
+                AFTER UPDATE ON secure_notes
+                FOR EACH ROW
+                BEGIN
+                    UPDATE secure_notes SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+                END;
+            `);
+
+            // Secure Files table
+            db.run(`CREATE TABLE IF NOT EXISTS secure_files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                file_name_encrypted TEXT NOT NULL,
+                file_type TEXT NOT NULL,
+                storage_path TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )`,
+            (err) => {
+                if (err) { /* Table already exists */ } else { console.log('Secure files table created.'); }
+            });
+
+            db.run(`
+                CREATE TRIGGER IF NOT EXISTS update_files_updated_at
+                AFTER UPDATE ON secure_files
+                FOR EACH ROW
+                BEGIN
+                    UPDATE secure_files SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+                END;
+            `);
         });
-
-        // Passwords table
-        db.run(`CREATE TABLE IF NOT EXISTS passwords (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            site TEXT NOT NULL,
-            username TEXT NOT NULL,
-            password TEXT NOT NULL,
-            category TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )`,
-        (err) => {
-            if (err) {
-                // Table already exists
-            } else {
-                console.log('Passwords table created.');
-            }
-        });
-
-        // Password History table
-        db.run(`CREATE TABLE IF NOT EXISTS password_history (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            password_id INTEGER NOT NULL,
-            site TEXT NOT NULL,
-            username TEXT NOT NULL,
-            password TEXT NOT NULL,
-            category TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (password_id) REFERENCES passwords(id) ON DELETE CASCADE
-        )`,
-        (err) => {
-            if (err) { /* Table already exists */ } else { console.log('Password history table created.'); }
-        });
-
-        // Secure Notes table
-        db.run(`CREATE TABLE IF NOT EXISTS secure_notes (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            title TEXT NOT NULL,
-            content TEXT NOT NULL,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )`,
-        (err) => {
-            if (err) { /* Table already exists */ } else { console.log('Secure notes table created.'); }
-        });
-
-        db.run(`
-            CREATE TRIGGER IF NOT EXISTS update_notes_updated_at
-            AFTER UPDATE ON secure_notes
-            FOR EACH ROW
-            BEGIN
-                UPDATE secure_notes SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
-            END;
-        `);
-
-        // Secure Files table
-        db.run(`CREATE TABLE IF NOT EXISTS secure_files (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            file_name_encrypted TEXT NOT NULL,
-            file_type TEXT NOT NULL,
-            storage_path TEXT NOT NULL,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )`,
-        (err) => {
-            if (err) { /* Table already exists */ } else { console.log('Secure files table created.'); }
-        });
-
-        db.run(`
-            CREATE TRIGGER IF NOT EXISTS update_files_updated_at
-            AFTER UPDATE ON secure_files
-            FOR EACH ROW
-            BEGIN
-                UPDATE secure_files SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
-            END;
-        `);
     }
 });
 


### PR DESCRIPTION
Wraps the `CREATE TABLE` statements in `database.js` within a `db.serialize()` block.

This prevents a race condition where the server could start accepting requests before all tables were created, which could cause "table not found" errors on a fresh startup.

This makes the database initialization more robust and reliable.